### PR TITLE
Change TxOut format

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -652,23 +652,13 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     }
 
     @Override
-    public String asm() {
-      return mapStr("asm");
-    }
-
-    @Override
-    public String hex() {
-      return mapStr("hex");
+    public ScriptPubKey scriptPubKey() {
+      return new ScriptPubKeyImpl((Map) m.get("scriptPubKey"));
     }
 
     @Override
     public long reqSigs() {
       return mapLong("reqSigs");
-    }
-
-    @Override
-    public String type() {
-      return mapStr("type");
     }
 
     @Override
@@ -965,6 +955,39 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     return (String) query("getrawtransaction", txId);
   }
 
+  private class ScriptPubKeyImpl extends MapWrapper implements ScriptPubKey, Serializable {
+
+    public ScriptPubKeyImpl(Map m) {
+      super(m);
+    }
+
+    @Override
+    public String asm() {
+      return mapStr("asm");
+    }
+
+    @Override
+    public String hex() {
+      return mapStr("hex");
+    }
+
+    @Override
+    public int reqSigs() {
+      return mapInt("reqSigs");
+    }
+
+    @Override
+    public String type() {
+      return mapStr("type");
+    }
+
+    @Override
+    public List<String> addresses() {
+      return (List) m.get("addresses");
+    }
+
+  }
+
   private class RawTransactionImpl extends MapWrapper implements RawTransaction, Serializable {
 
     public RawTransactionImpl(Map<String, Object> tx) {
@@ -1084,39 +1107,6 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
       @Override
       public int n() {
         return mapInt("n");
-      }
-
-      private class ScriptPubKeyImpl extends MapWrapper implements ScriptPubKey, Serializable {
-
-        public ScriptPubKeyImpl(Map m) {
-          super(m);
-        }
-
-        @Override
-        public String asm() {
-          return mapStr("asm");
-        }
-
-        @Override
-        public String hex() {
-          return mapStr("hex");
-        }
-
-        @Override
-        public int reqSigs() {
-          return mapInt("reqSigs");
-        }
-
-        @Override
-        public String type() {
-          return mapStr("type");
-        }
-
-        @Override
-        public List<String> addresses() {
-          return (List) m.get("addresses");
-        }
-
       }
 
       @Override

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -405,20 +405,15 @@ public interface BitcoindRpcClient {
 
     public BigDecimal value();
 
-    public String asm();
-
-    public String hex();
+    public ScriptPubKey scriptPubKey();
 
     public long reqSigs();
-
-    public String type();
 
     public List<String> addresses();
 
     public long version();
 
     public boolean coinBase();
-
   }
 
   public static interface Block extends Serializable {
@@ -493,6 +488,19 @@ public interface BitcoindRpcClient {
 
   public String getRawTransactionHex(String txId) throws BitcoinRpcException;
 
+  public interface ScriptPubKey extends Serializable {
+
+    public String asm();
+
+    public String hex();
+
+    public int reqSigs();
+
+    public String type();
+
+    public List<String> addresses();
+  }
+
   public interface RawTransaction extends Serializable {
 
     public String hex();
@@ -535,19 +543,6 @@ public interface BitcoindRpcClient {
       public double value();
 
       public int n();
-
-      public interface ScriptPubKey extends Serializable {
-
-        public String asm();
-
-        public String hex();
-
-        public int reqSigs();
-
-        public String type();
-
-        public List<String> addresses();
-      }
 
       public ScriptPubKey scriptPubKey();
 

--- a/src/test/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientTest.java
+++ b/src/test/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import wf.bitcoin.krotjson.JSON;
 
 import java.util.LinkedList;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
@@ -96,5 +97,25 @@ public class BitcoinJSONRPCClientTest {
         String hex = client.signRawTransaction("0100000001B8B2244FACA910C1FFFF24ECD2B559B4699338398BF77E4CB1FDEB19AD419EA0010000001976A9144CB4C3B90994FEF58FABB6D8368302E917C6EFB188ACFFFFFFFF012E2600000000000017A9140B2D7ED4E5076383BA8E98B9B3BCE426B7A2EA1E8700000000");
         assertEquals("0100000001b8b2244faca910c1ffff24ecd2b559b4699338398bf77e4cb1fdeb19ad419ea0010000006b483045022100b68b7fe9cfabb32949af6747b6769dffcf2aa4170e4df2f0e9d0a4571989e94e02204cf506c210cdb6b6b4413bf251a0b57ebcf1b1b2d303ba6183239b557ef0a310012102ab46e1d7b997d8094e97bc06a21a054c2ef485fac512e2dc91eb9831af55af4effffffff012e2600000000000017a9140b2d7ed4e5076383ba8e98b9b3bce426b7a2ea1e8700000000",
                     hex);
+    }
+
+    @Test
+    public void txOutTest() throws Exception {
+        client = new MyClientTest(false, "gettxout", null,
+                "{\n" +
+                        "  \"bestblock\": \"55d2df879d7efc960628ae8d15352c904edfa5d716e31871cce6de5f05174986\",\n" +
+                        "  \"confirmations\": 551,\n" +
+                        "  \"value\": 0.02000000,\n" +
+                        "  \"scriptPubKey\": {\n" +
+                        "    \"asm\": \"0 955d569f9812bfe6796cbab7263f4cf90cc18c05c09a6e2eff3a890c2c5966af\",\n" +
+                        "    \"hex\": \"0020955d569f9812bfe6796cbab7263f4cf90cc18c05c09a6e2eff3a890c2c5966af\",\n" +
+                        "    \"type\": \"witness_v0_scripthash\"\n" +
+                        "  },\n" +
+                        "  \"version\": 2,\n" +
+                        "  \"coinbase\": false\n" +
+                        "}");
+
+        assertEquals(client.getTxOut("77c412efb79cbef9c13b40d2b146b529d399beced3c906df65bfb5973c3c2882", 0)
+                .scriptPubKey().hex(), "0020955d569f9812bfe6796cbab7263f4cf90cc18c05c09a6e2eff3a890c2c5966af");
     }
 }


### PR DESCRIPTION
Bitcoin Core 0.14.1 output format for `gettxout` differs from what is currently expected in `JavaBitcoindRpcClient`. Instead of `asm`, `hex` and `type` fields in `TxOut` interface 0.14.1 returns a `scriptPubKey` field which contains those inside.  

As far as I can see this new `scriptPubKey` object type is similar to one already present in `BitcoindRpcClient.RawTransaction.Out.ScriptPubKey` interface so I've just changed it's scope to `BitcoindRpcClient.ScriptPubKey` such that it's visible to both `TxOut` and `RawTransaction` (and the same for `ScriptPubKeyImpl`).  

Not sure if that's the right way to do it, please let me know if it isn't.
