### PR TITLE
support 'getaddressutxo' APIs which are provided by some nodes with an option 'addressindex' supported

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient2.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient2.java
@@ -5,22 +5,17 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * an encapsulation of APIs provided by BitPay
- * 
- * internal use only
- * 
  * @author frankchen
  * @create 2018年5月24日 下午3:00:04
  */
-public class BitcoinJSONRPCClientExt extends BitcoinJSONRPCClient implements BitcoindRpcClient2
+public class BitcoinJSONRPCClient2 extends BitcoinJSONRPCClient implements BitcoindRpcClient2
 {
-    public BitcoinJSONRPCClientExt(URL url)
+    public BitcoinJSONRPCClient2(URL url)
     {
         super(url);
     }
 
     /**
-     * API provided by bitpay's bitcored
      * @param address
      * @return balance is in unit of satoshis
      */

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientExt.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientExt.java
@@ -1,0 +1,151 @@
+package wf.bitcoin.javabitcoindrpcclient;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * an encapsulation of APIs provided by BitPay
+ * 
+ * internal use only
+ * 
+ * @author frankchen
+ * @create 2018年5月24日 下午3:00:04
+ */
+public class BitcoinJSONRPCClientExt extends BitcoinJSONRPCClient
+{
+    public BitcoinJSONRPCClientExt(URL url)
+    {
+        super(url);
+    }
+
+    public static class AddressBalance extends MapWrapper
+    {
+        private long balanceInSatoshis;
+        private long received;
+        
+        public AddressBalance(Map<String, Object> r)
+        {
+            super(r);
+            balanceInSatoshis = ((Number)r.get("balance")).longValue();
+            received = ((Number)r.get("received")).longValue();
+        }
+
+        /**
+         * unit is in satoshis
+         * 
+         * eg, 5,3500,000 = 0.535 BTC
+         */
+        public long getBalanceInSatoshis()
+        {
+            return balanceInSatoshis;
+        }
+
+        public long getReceived()
+        {
+            return received;
+        }
+    }
+
+    /**
+     * API provided by bitpay's bitcored
+     * @param address
+     * @return balance is in unit of satoshis
+     */
+    @SuppressWarnings("unchecked")
+    public AddressBalance getAddressBalance(String address)
+    {
+        return new AddressBalance((Map<String, Object>)query("getaddressbalance", address));
+    }
+
+    //    "address": "mse5PYo8iCevsv2DyFFvna8msQFnB8b7Bd",
+    //    "txid": "2278c94ca3b59ee2ab9b7c863d745002581a401efc26aed3963a120cccf8a4a7",
+    //    "outputIndex": 1,
+    //    "script": "76a91484fa57f18e3e7b40eb84097cce323b6f248857b388ac",
+    //    "satoshis": 53500000,
+    //    "height": 1298221
+    public static class AddressUtxo
+    {
+        private String address;
+        private String txid;
+        private int outputIndex;
+        private String script;
+        private long satoshis;
+        private long height;
+        
+        public AddressUtxo(Map<String, Object> result)
+        {
+            address = result.getOrDefault("address","").toString();
+            txid = result.getOrDefault("txid","").toString();
+            outputIndex = ((Number)result.getOrDefault("outputIndex","")).intValue();
+            script = result.getOrDefault("script","").toString();
+            satoshis = ((Number)result.getOrDefault("satoshis",0)).longValue();
+            height = ((Number)result.getOrDefault("height", -1)).longValue();
+        }
+        
+        public String getAddress()
+        {
+            return address;
+        }
+
+        public String getTxid()
+        {
+            return txid;
+        }
+
+        public int getOutputIndex()
+        {
+            return outputIndex;
+        }
+
+        public String getScript()
+        {
+            return script;
+        }
+
+        public long getSatoshis()
+        {
+            return satoshis;
+        }
+
+        public long getHeight()
+        {
+            return height;
+        }
+    }
+    
+    public static class AddressUtxoList extends ListMapWrapper<AddressUtxo>
+    {
+        @SuppressWarnings("rawtypes")
+        public AddressUtxoList(List<Map> list)
+        {
+            super((List<Map>)list);
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Override
+        protected AddressUtxo wrap(Map m)
+        {
+            return new AddressUtxo(m);
+        }
+    }
+    
+    /**
+     * @param address public key address in base58check encoding
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public List<AddressUtxo> getAddressUtxo(String address)
+    {
+        return new AddressUtxoList((List<Map>)query("getaddressutxos", address));
+    }
+    
+    private Boolean isTestNet;
+    public boolean isTestNet()
+    {
+        if ( isTestNet == null )
+        {
+            isTestNet = new Boolean(getInfo().testnet());
+        }
+        return isTestNet;
+    }
+}

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientExt.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClientExt.java
@@ -12,39 +12,11 @@ import java.util.Map;
  * @author frankchen
  * @create 2018年5月24日 下午3:00:04
  */
-public class BitcoinJSONRPCClientExt extends BitcoinJSONRPCClient
+public class BitcoinJSONRPCClientExt extends BitcoinJSONRPCClient implements BitcoindRpcClient2
 {
     public BitcoinJSONRPCClientExt(URL url)
     {
         super(url);
-    }
-
-    public static class AddressBalance extends MapWrapper
-    {
-        private long balanceInSatoshis;
-        private long received;
-        
-        public AddressBalance(Map<String, Object> r)
-        {
-            super(r);
-            balanceInSatoshis = ((Number)r.get("balance")).longValue();
-            received = ((Number)r.get("received")).longValue();
-        }
-
-        /**
-         * unit is in satoshis
-         * 
-         * eg, 5,3500,000 = 0.535 BTC
-         */
-        public long getBalanceInSatoshis()
-        {
-            return balanceInSatoshis;
-        }
-
-        public long getReceived()
-        {
-            return received;
-        }
     }
 
     /**
@@ -58,78 +30,6 @@ public class BitcoinJSONRPCClientExt extends BitcoinJSONRPCClient
         return new AddressBalance((Map<String, Object>)query("getaddressbalance", address));
     }
 
-    //    "address": "mse5PYo8iCevsv2DyFFvna8msQFnB8b7Bd",
-    //    "txid": "2278c94ca3b59ee2ab9b7c863d745002581a401efc26aed3963a120cccf8a4a7",
-    //    "outputIndex": 1,
-    //    "script": "76a91484fa57f18e3e7b40eb84097cce323b6f248857b388ac",
-    //    "satoshis": 53500000,
-    //    "height": 1298221
-    public static class AddressUtxo
-    {
-        private String address;
-        private String txid;
-        private int outputIndex;
-        private String script;
-        private long satoshis;
-        private long height;
-        
-        public AddressUtxo(Map<String, Object> result)
-        {
-            address = result.getOrDefault("address","").toString();
-            txid = result.getOrDefault("txid","").toString();
-            outputIndex = ((Number)result.getOrDefault("outputIndex","")).intValue();
-            script = result.getOrDefault("script","").toString();
-            satoshis = ((Number)result.getOrDefault("satoshis",0)).longValue();
-            height = ((Number)result.getOrDefault("height", -1)).longValue();
-        }
-        
-        public String getAddress()
-        {
-            return address;
-        }
-
-        public String getTxid()
-        {
-            return txid;
-        }
-
-        public int getOutputIndex()
-        {
-            return outputIndex;
-        }
-
-        public String getScript()
-        {
-            return script;
-        }
-
-        public long getSatoshis()
-        {
-            return satoshis;
-        }
-
-        public long getHeight()
-        {
-            return height;
-        }
-    }
-    
-    public static class AddressUtxoList extends ListMapWrapper<AddressUtxo>
-    {
-        @SuppressWarnings("rawtypes")
-        public AddressUtxoList(List<Map> list)
-        {
-            super((List<Map>)list);
-        }
-
-        @SuppressWarnings({ "rawtypes", "unchecked" })
-        @Override
-        protected AddressUtxo wrap(Map m)
-        {
-            return new AddressUtxo(m);
-        }
-    }
-    
     /**
      * @param address public key address in base58check encoding
      */

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
@@ -81,13 +81,15 @@ public class BitcoinRPCException extends GenericRpcException {
     return rpcParams;
   }
 
+  /**
+   * @return the HTTP response message
+   */
   public String getResponseMessage() {
     return responseMessage;
   }
 
   /**
-   * the msg from bitcoind
-   * @return
+   * @return response message from bitcored
    */
   public String getResponse() {
       return this.response;

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
@@ -85,4 +85,11 @@ public class BitcoinRPCException extends GenericRpcException {
     return responseMessage;
   }
 
+  /**
+   * the msg from bitcoind
+   * @return
+   */
+  public String getResponse() {
+      return this.response;
+  }
 }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRawTxBuilder.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRawTxBuilder.java
@@ -23,6 +23,7 @@ public class BitcoinRawTxBuilder {
   }
   public Set<BitcoindRpcClient.TxInput> inputs = new LinkedHashSet<>();
   public List<BitcoindRpcClient.TxOutput> outputs = new ArrayList<>();
+  public List<String> privateKeys;
 
   private class Input extends BitcoindRpcClient.BasicTxInput {
 
@@ -114,13 +115,21 @@ public class BitcoinRawTxBuilder {
       out(address, BitcoinUtil.normalizeAmount(is - os));
     return this;
   }
+  
+  public BitcoinRawTxBuilder addPrivateKey(String privateKey)
+  {
+	  if ( privateKeys == null )
+		  privateKeys = new ArrayList<String>();
+	  privateKeys.add(privateKey);
+	  return this;
+  }
 
   public String create() throws GenericRpcException {
     return bitcoin.createRawTransaction(new ArrayList<>(inputs), outputs);
   }
 
   public String sign() throws GenericRpcException {
-    return bitcoin.signRawTransaction(create(), null, null);
+    return bitcoin.signRawTransaction(create(), null, privateKeys);
   }
 
   public String send() throws GenericRpcException {

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient2.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient2.java
@@ -3,11 +3,19 @@ package wf.bitcoin.javabitcoindrpcclient;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * an extended client used to consume APIS, such as 'getaddressutxo',
+ * which are provided by some btc nodes which supports 'addressindex'. <br/>
+ * taking a look at <a href="https://github.com/satoshilabs/bitcoin">satoshilabs/bitcoin</a> 
+ * 
+ * @author frankchen
+ * @create 2018年6月21日 上午10:38:17
+ */
 public interface BitcoindRpcClient2 extends BitcoindRpcClient
 {
     /**
      * the result returned by
-     * {@link BitcoinJSONRPCClientExt#getAddressBalance(String)}
+     * {@link BitcoinJSONRPCClient2#getAddressBalance(String)}
      * 
      * @author frankchen
      * @create 2018年6月21日 上午10:38:17
@@ -40,12 +48,11 @@ public interface BitcoindRpcClient2 extends BitcoindRpcClient
         }
     }
 
-    // "address": "mse5PYo8iCevsv2DyFFvna8msQFnB8b7Bd",
-    // "txid": "2278c94ca3b59ee2ab9b7c863d745002581a401efc26aed3963a120cccf8a4a7",
-    // "outputIndex": 1,
-    // "script": "76a91484fa57f18e3e7b40eb84097cce323b6f248857b388ac",
-    // "satoshis": 53500000,
-    // "height": 1298221
+    /**
+     * the result return by {@link BitcoinJSONRPCClient2#getAddressUtxo(String)}
+     * @author frankchen
+     * @create 2018年6月21日 上午10:38:17
+     */
     public class AddressUtxo
     {
         private String address;
@@ -70,6 +77,9 @@ public interface BitcoindRpcClient2 extends BitcoindRpcClient
             return address;
         }
 
+        /**
+         * the txid of this uxto
+         */
         public String getTxid()
         {
             return txid;
@@ -90,6 +100,10 @@ public interface BitcoindRpcClient2 extends BitcoindRpcClient
             return satoshis;
         }
 
+        /**
+         * height of block in which this utxo is
+         * @return
+         */
         public long getHeight()
         {
             return height;
@@ -114,11 +128,17 @@ public interface BitcoindRpcClient2 extends BitcoindRpcClient
     
 
     /**
-     * API provided by bitcoin which supports 'addressindex' option 
-     * @param address
-     * @return balance is in unit of satoshis
+     * get the balance of specified address
      */
     AddressBalance getAddressBalance(String address);
+    
+    /**
+     * get all the utxo list of a specified address
+     */
     List<AddressUtxo> getAddressUtxo(String address);
+    
+    /**
+     * check whether the node is running in a test net or not 
+     */
     boolean isTestNet();
 }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient2.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient2.java
@@ -1,0 +1,124 @@
+package wf.bitcoin.javabitcoindrpcclient;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BitcoindRpcClient2 extends BitcoindRpcClient
+{
+    /**
+     * the result returned by
+     * {@link BitcoinJSONRPCClientExt#getAddressBalance(String)}
+     * 
+     * @author frankchen
+     * @create 2018年6月21日 上午10:38:17
+     */
+    public static class AddressBalance extends MapWrapper
+    {
+        private long balance;
+        private long received;
+
+        public AddressBalance(Map<String, Object> r)
+        {
+            super(r);
+            balance = ((Number) r.get("balance")).longValue();
+            received = ((Number) r.get("received")).longValue();
+        }
+
+        /**
+         * unit is in satoshis
+         * 
+         * eg, 5,3500,000 = 0.535 BTC
+         */
+        public long getBalance()
+        {
+            return balance;
+        }
+
+        public long getReceived()
+        {
+            return received;
+        }
+    }
+
+    // "address": "mse5PYo8iCevsv2DyFFvna8msQFnB8b7Bd",
+    // "txid": "2278c94ca3b59ee2ab9b7c863d745002581a401efc26aed3963a120cccf8a4a7",
+    // "outputIndex": 1,
+    // "script": "76a91484fa57f18e3e7b40eb84097cce323b6f248857b388ac",
+    // "satoshis": 53500000,
+    // "height": 1298221
+    public class AddressUtxo
+    {
+        private String address;
+        private String txid;
+        private int    outputIndex;
+        private String script;
+        private long   satoshis;
+        private long   height;
+
+        public AddressUtxo(Map<String, Object> result)
+        {
+            address = result.getOrDefault("address", "").toString();
+            txid = result.getOrDefault("txid", "").toString();
+            outputIndex = ((Number) result.getOrDefault("outputIndex", "")).intValue();
+            script = result.getOrDefault("script", "").toString();
+            satoshis = ((Number) result.getOrDefault("satoshis", 0)).longValue();
+            height = ((Number) result.getOrDefault("height", -1)).longValue();
+        }
+
+        public String getAddress()
+        {
+            return address;
+        }
+
+        public String getTxid()
+        {
+            return txid;
+        }
+
+        public int getOutputIndex()
+        {
+            return outputIndex;
+        }
+
+        public String getScript()
+        {
+            return script;
+        }
+
+        public long getSatoshis()
+        {
+            return satoshis;
+        }
+
+        public long getHeight()
+        {
+            return height;
+        }
+    }
+    
+    public class AddressUtxoList extends ListMapWrapper<AddressUtxo>
+    {
+        @SuppressWarnings("rawtypes")
+        public AddressUtxoList(List<Map> list)
+        {
+            super((List<Map>)list);
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Override
+        protected AddressUtxo wrap(Map m)
+        {
+            return new AddressUtxo(m);
+        }
+    }
+    
+
+    /**
+     * API provided by bitcoin which supports 'addressindex' option 
+     * @param address
+     * @return balance is in unit of satoshis
+     */
+    AddressBalance getAddressBalance(String address);
+    List<AddressUtxo> getAddressUtxo(String address);
+    boolean isTestNet();
+}


### PR DESCRIPTION
some BTC nodes customize the official nodes to support to get balance/utxo of any given address. These customized functions are very important to develop some products/services such as wallet.

Unfortunately, these customized APIs have not been merged into the official bitcoin nodes but are still being widely used, such as https://github.com/satoshilabs/bitcoin, or https://github.com/bitpay/bitcore-node.

To support these customized APIs, I add a new interface which is named as `BitcoindRpcClient2` so that there are no changes to the original interface `BitcoindRpcClient`.

Also, there are two other minor improvements.
First, there is a new a method `addPrivateKey` in `BitcoinRawTxBuilder`, so that we can specify a customized private key to sign message.

Second, `getResponse` is provided in `BitcoinRPCException` to allow to retrieve message returned from bitcoind