### PR TITLE
support 'address' property in RawTransaction.In interface

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -1194,6 +1194,10 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
         return mapStr("scriptPubKey");
       }
 
+      @Override
+      public String address() {
+          return mapStr("address");
+      }
     }
 
     @Override

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -691,6 +691,14 @@ public interface BitcoindRpcClient {
       RawTransaction getTransaction();
 
       Out getTransactionOutput();
+      
+      /**
+       * get the spent address, which is specified in the 'scriptPubKey' in the connected output of this tx </br>
+       * <b>PAY ATTENTION</b> This property is only supported by those bitcoind which supports a '-spentindex' option<br/>
+       * For more information about 'spentindex', take a look at <a href="https://github.com/satoshilabs/bitcoin">satoshilabs/bitcoin</a>
+       * or <a href="https://github.com/bitpay/bitcoin">bitpay/bitcoin</a>
+       */
+      String address();
     }
 
     /**


### PR DESCRIPTION
some bitcoin nodes support extra properties on the input of a transaction. this pull request adds one of such properties that is 'address' which is widely used