### PR TITLE
fix NullPointerException when getting 'confirmations' on an unconfirmed tx

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -1307,7 +1307,8 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
 
     @Override
     public Integer confirmations() {
-      return this.m.containsKey("confirmations") ? mapInt("confirmations") : null;
+      Object o = m.get("confirmations");
+      return o == null ? null : ((Number)o).intValue();
     }
 
     @Override

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -1306,8 +1306,8 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     }
 
     @Override
-    public int confirmations() {
-      return mapInt("confirmations");
+    public Integer confirmations() {
+      return this.m.containsKey("confirmations") ? mapInt("confirmations") : null;
     }
 
     @Override

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -741,7 +741,10 @@ public interface BitcoindRpcClient {
 
     String blockHash();
 
-    int confirmations();
+    /**
+     * @return null if this tx has not been included in a block
+     */
+    Integer confirmations();
 
     Date time();
 

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -742,12 +742,20 @@ public interface BitcoindRpcClient {
     String blockHash();
 
     /**
-     * @return null if this tx has not been included in a block
+     * @return null if this tx has not been confirmed yet
      */
     Integer confirmations();
 
+    /**
+     * 
+     * @return null if this tx has not been confirmed yet
+     */
     Date time();
 
+    /**
+     * 
+     * @return null if this tx has not been confirmed yet
+     */
     Date blocktime();
   }
 


### PR DESCRIPTION
`getRawTransaction` provided by bitcoind always returns a JSON object without `confirmations` property if the tx has not been confirmed. 

Currently, `confirmations()` calls `mapInt` to get and return the `confirmation` property, if there's no such property, there's a NullPointerException. 

I change the return type of `confirmations()` from `int` to `Integer`, so that a null can be returned in such condition. and user code can handle such a problem by just checking if the value is null.

This change  is compatible for all the user code.