### PR TITLE
support to get error code and message returned from bitcoind easily

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -184,6 +184,7 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     return o.toByteArray();
   }
 
+  @SuppressWarnings("rawtypes")
   public Object loadResponse(InputStream in, Object expectedID, boolean close) throws IOException, GenericRpcException {
     try {
       String r = new String(loadStream(in, close), QUERY_CHARSET);
@@ -195,7 +196,7 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
           throw new BitcoinRPCException("Wrong response ID (expected: " + String.valueOf(expectedID) + ", response: " + response.get("id") + ")");
 
         if (response.get("error") != null)
-          throw new GenericRpcException(JSON.stringify(response.get("error")));
+          throw new BitcoinRPCException(new BitcoinRPCError((Map)response.get("error")));
 
         return response.get("result");
       } catch (ClassCastException ex) {

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
@@ -1,0 +1,49 @@
+/*
+ * Bitcoin-JSON-RPC-Client License
+ * 
+ * Copyright (c) 2013, Mikhail Yevchenko.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 
+ * Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+ * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package wf.bitcoin.javabitcoindrpcclient;
+
+import java.util.Map;
+
+/**
+ * an object represents the error in a bitcoind rpc call
+ * 
+ * @author frankchen
+ * @create 2018年7月9日 下午8:58:13
+ */
+public class BitcoinRPCError {
+	private int code;
+	private String message;
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public BitcoinRPCError(Map errorMap) {
+		this.code = (int) errorMap.getOrDefault("code", 0);
+		this.message = (String) errorMap.get("message");
+	}
+
+	/**
+	 * get the code returned by the bitcoind.<br/>
+	 * some of the error codes are defined in {@link BitcoinRPCErrorCode}
+	 */
+	public int getCode() {
+		return code;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
@@ -26,24 +26,24 @@ import java.util.Map;
  * @create 2018年7月9日 下午8:58:13
  */
 public class BitcoinRPCError {
-	private int code;
-	private String message;
+    private int code;
+    private String message;
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public BitcoinRPCError(Map errorMap) {
-		this.code = (int) errorMap.getOrDefault("code", 0);
-		this.message = (String) errorMap.get("message");
-	}
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public BitcoinRPCError(Map errorMap) {
+        this.code = (int) errorMap.getOrDefault("code", 0);
+        this.message = (String) errorMap.get("message");
+    }
 
-	/**
-	 * get the code returned by the bitcoind.<br/>
-	 * some of the error codes are defined in {@link BitcoinRPCErrorCode}
-	 */
-	public int getCode() {
-		return code;
-	}
+    /**
+     * get the code returned by the bitcoind.<br/>
+     * some of the error codes are defined in {@link BitcoinRPCErrorCode}
+     */
+    public int getCode() {
+        return code;
+    }
 
-	public String getMessage() {
-		return message;
-	}
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCErrorCode.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCErrorCode.java
@@ -1,0 +1,39 @@
+/*
+ * Bitcoin-JSON-RPC-Client License
+ * 
+ * Copyright (c) 2013, Mikhail Yevchenko.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 
+ * Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+ * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package wf.bitcoin.javabitcoindrpcclient;
+
+/**
+ * error code returned from bitcoind
+ * @author frankchen
+ * @create 2018年7月9日 下午8:58:52
+ */
+public class BitcoinRPCErrorCode {
+    public static final int RPC_MISC_ERROR                  = -1 ;  //!< std::exception thrown in command handling
+    public static final int RPC_FORBIDDEN_BY_SAFE_MODE      = -2 ;  //!< Server is in safe mode, and command is not allowed in safe mode
+    public static final int RPC_TYPE_ERROR                  = -3 ;  //!< Unexpected type was passed as parameter
+    public static final int RPC_INVALID_ADDRESS_OR_KEY      = -5 ;  //!< Invalid address or key
+    public static final int RPC_OUT_OF_MEMORY               = -7 ;  //!< Ran out of memory during operation
+    public static final int RPC_INVALID_PARAMETER           = -8 ;  //!< Invalid, missing or duplicate parameter
+    public static final int RPC_DATABASE_ERROR              = -20; //!< Database error
+    public static final int RPC_DESERIALIZATION_ERROR       = -22; //!< Error parsing or validating structure in raw format
+    public static final int RPC_VERIFY_ERROR                = -25; //!< General error during transaction or block submission
+    public static final int RPC_VERIFY_REJECTED             = -26; //!< Transaction or block was rejected by network rules
+    public static final int RPC_VERIFY_ALREADY_IN_CHAIN     = -27; //!< Transaction already in chain
+    public static final int RPC_IN_WARMUP                   = -28; //!< Client still warming up
+
+}


### PR DESCRIPTION
all the errors of RPC calls returned by bitcoind are written into a json property named `error`, which contains two properties: `code` and `message`。

sometimes, we want to handle some of these errors. eg, if an invalid txid is given to the `getRawTransaction` request, a error code (-5), which means invalid key, is returned.

in order to do so, we need to get the error code. Currently, there are no methods provided to do the things easily.

`response` message in BitcoinRPCException holds the string of error json object, but it's too boring for callers to extract error code and message from this string. so, here's the pull-request addressing this problem. 

I've added two classes, one is `BitcoinRPCError`, which represents the `error` json object returned by bitcoind, and the other one is `BitcoinRPCErrorCode`, which defines some constants defined in bitcoind to represent different errors.

a `rpcError` property is also added to `BitcoinRPCException`, so that we can get the error code and message whenever there's is such an exception

here's an example of how to use the new interfaces

````
    public Object getTransaction(String txId)
    {
        try
        {
            return btcClient.getRawTransaction(txId);
        }
        catch(BitcoinRPCException e)
        {
            if ( e.getRPCError() != null 
              && e.getRPCError().getCode() == BitcoinRPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY )
                return null;
            throw e;
        }
    }
````