### PR TITLE
fix a bug which causes type cast exception

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
@@ -29,9 +29,10 @@ public class BitcoinRPCError {
     private int code;
     private String message;
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({ "rawtypes" })
     public BitcoinRPCError(Map errorMap) {
-        this.code = (int) errorMap.getOrDefault("code", 0);
+        Number n = (Number) errorMap.get("code");
+        this.code    = n != null ? n.intValue() : 0;
         this.message = (String) errorMap.get("message");
     }
 


### PR DESCRIPTION
This bug is caused by pull request #57 . the type of `code` in `Map` is `Long`, which can't be cast into `int`