### PR TITLE
fix a NullPointerException when authorization fails

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -230,8 +230,14 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
       conn.getOutputStream().write(r);
       conn.getOutputStream().close();
       int responseCode = conn.getResponseCode();
-      if (responseCode != 200)
-        throw new BitcoinRPCException(method, Arrays.deepToString(o), responseCode, conn.getResponseMessage(), new String(loadStream(conn.getErrorStream(), true)));
+      if (responseCode != 200) {
+        InputStream errorStream = conn.getErrorStream();
+        throw new BitcoinRPCException(method, 
+                                      Arrays.deepToString(o), 
+                                      responseCode, 
+                                      conn.getResponseMessage(), 
+                                      errorStream == null ? null : new String(loadStream(errorStream, true)));
+      }
       return loadResponse(conn.getInputStream(), "1", true);
     } catch (IOException ex) {
       throw new BitcoinRPCException(method, Arrays.deepToString(o), ex);


### PR DESCRIPTION
when a wrong password is provided to access the bitcoind, `BitcoinJSONRPCClient`  throws a `NullPointerException` which says the object with type of `InputStream` in `loadStream()` method is null. here's the stack trace

````
java.lang.NullPointerException
	at wf.bitcoin.javabitcoindrpcclient.BitcoinJSONRPCClient.loadStream(BitcoinJSONRPCClient.java:175)
	at wf.bitcoin.javabitcoindrpcclient.BitcoinJSONRPCClient.query(BitcoinJSONRPCClient.java:234)
	at wf.bitcoin.javabitcoindrpcclient.BitcoinJSONRPCClient.getRawTransaction(BitcoinJSONRPCClient.java:1436)
````

I fix this bug by prechecking the `conn.getErrorStream()`, if it's null, doing something else to prevent such exception